### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/css/clamp/index.md
+++ b/files/en-us/web/css/clamp/index.md
@@ -56,7 +56,7 @@ Keep the following aspects in mind while working with the function:
 
 `clamp(MIN, VAL, MAX)` is resolved as `{{CSSxRef("max", "max")}}(MIN, {{CSSxRef("min", "min")}}(VAL, MAX))`.
 
-Based on the provided parameters, the function returns {{CSSxRef("&lt;length&gt;")}}, {{CSSxRef("&lt;frequency&gt;")}}, {{CSSxRef("&lt;angle&gt;")}}, {{CSSxRef("&lt;time&gt;")}}, {{CSSxRef("&lt;percentage&gt;")}}, {{CSSxRef("&lt;number&gt;")}}, or {{CSSxRef("&lt;integer&gt;")}}.
+Based on the provided parameters, the function returns {{CSSxRef("&lt;length&gt;")}}, {{CSSxRef("&lt;frequency&gt;")}}, {{CSSxRef("&lt;angle&gt;")}}, {{CSSxRef("&lt;time&gt;")}}, {{CSSxRef("&lt;percentage&gt;")}}, {{CSSxRef("&lt;number&gt;")}}, or {{CSSxRef("&lt;integer&gt;")}}. Because the clamp() function can return any of these types, it can be used to calculate the value for any CSS property that also uses these same types.
 
 ### Formal syntax
 


### PR DESCRIPTION
adds a statement to affirmatively confirm that clamp() can be used for multiple situations, as a user reading this article may learn towards thinking it is only towards a few of the items mentioned in the article.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

As the article has heavy explanations on using clamp() for font-size, I thought it would help to confirm that it can be used for multiple other properties.

### Motivation

I was trying to use clamp() and my browser kept rejecting how I was typing it.  After checking and seeing my syntax was correct I wondered if maybe I was applying it to an incorrect property.  I couldn't find a place where it listed which properties I could use it worth, so I thought this would add value.  For my research I referred to https://www.w3.org/TR/css-values-4/#funcdef-clamp.

### Additional details

See https://www.w3.org/TR/css-values-4/#funcdef-clamp for the source of my information.

### Related issues and pull requests
